### PR TITLE
Improve vendor product validation and date formatting

### DIFF
--- a/resources/views/vendor/help-support/partials/table.blade.php
+++ b/resources/views/vendor/help-support/partials/table.blade.php
@@ -23,7 +23,7 @@
             <td>{{ $result->request_id ?? '-' }}</td>
             <td>{{ $result->creater->name ?? '-' }}</td>
             <td>{{ $result->venderBuyer->legal_name ?? '-' }}</td>
-            <td>{{ date('d/m/Y', strtotime($result->created_at)) }}</td>
+            <td>{{ date('d-m-Y', strtotime($result->created_at)) }}</td>
             <td>{{ $result->issue_type}}</td>
             @php 
             if(strlen($result->description) > 20) {

--- a/resources/views/vendor/live-auction/partials/table.blade.php
+++ b/resources/views/vendor/live-auction/partials/table.blade.php
@@ -21,7 +21,7 @@
         @forelse ($results as $result)
         <tr> 
             <td class="align-middle">{{ $result->rfq_no }}</td>
-            <td class="align-middle">{{ date('d/m/Y', strtotime($result->rfq_auction->rfq->created_at)) }}</td>
+            <td class="align-middle">{{ date('d-m-Y', strtotime($result->rfq_auction->rfq->created_at)) }}</td>
             <td>
                 @php
                     $variant = $result->rfq_auction->rfq_auction_variant->first();
@@ -37,7 +37,7 @@
             </td>
             <td class="align-middle">{{ $result->rfq_auction->buyer->legal_name ?? '-' }}</td>
             <td class="align-middle">{{ $result->rfq_auction->buyer->users->name ?? '-' }}</td>
-            <td class="align-middle">{{ date('d/m/Y', strtotime($result->rfq_auction->auction_date)) }}</td>
+            <td class="align-middle">{{ date('d-m-Y', strtotime($result->rfq_auction->auction_date)) }}</td>
             <td class="align-middle">{{ date('h:i A', strtotime($result->rfq_auction->auction_start_time)) }} To {{ date('h:i A', strtotime($result->rfq_auction->auction_end_time)) }}</td>
             <td class="align-middle"></td>
             <td class="align-middle">

--- a/resources/views/vendor/order/direct-pdf.blade.php
+++ b/resources/views/vendor/order/direct-pdf.blade.php
@@ -164,7 +164,7 @@
                                 <tr>
                                     <td style="width: 45%;">
                                         <p class="fc1"><b>Order Date :
-                                            </b><?php echo date('d/m/Y', strtotime($order->created_at)); ?></p>
+                                            </b><?php echo date('d-m-Y', strtotime($order->created_at)); ?></p>
                                     </td>
                                 </tr>
                                 <tr>

--- a/resources/views/vendor/order/direct-view.blade.php
+++ b/resources/views/vendor/order/direct-view.blade.php
@@ -47,7 +47,7 @@ ul.add-FQR-list li {
             <div class="card-body">
                 <ul class="add-FQR-list">
                     <li>Order No: {{ $order->manual_po_number }}</li>
-                    <li>Order Date: {{ date('d/m/Y', strtotime($order->created_at)) }}</li>
+                    <li>Order Date: {{ date('d-m-Y', strtotime($order->created_at)) }}</li>
                     <li>Buyer Name: {{ $order->buyer->legal_name ?? '-' }}</li>
                     <li>Branch/Unit : {{$order->order_products[0]->inventory->branch->name}}</li>
                 </ul>

--- a/resources/views/vendor/order/partials/direct-table.blade.php
+++ b/resources/views/vendor/order/partials/direct-table.blade.php
@@ -19,7 +19,7 @@
 
         @forelse ($results as $result)
         <tr>
-            <td>{{ date('d/m/Y', strtotime($result->created_at)) }}</td>
+            <td>{{ date('d-m-Y', strtotime($result->created_at)) }}</td>
             <td>
                 <a href="{{ route('vendor.direct_order.show', $result->id) }}">
                 {{ $result->manual_po_number ?? '-' }}

--- a/resources/views/vendor/order/partials/rfq-table.blade.php
+++ b/resources/views/vendor/order/partials/rfq-table.blade.php
@@ -21,7 +21,7 @@
 
         @forelse ($results as $result)
         <tr>
-            <td>{{ date('d/m/Y', strtotime($result->created_at)) }}</td>
+            <td>{{ date('d-m-Y', strtotime($result->created_at)) }}</td>
             <td>
                 <a href="{{ route('vendor.rfq_order.show', $result->id) }}">
                 {{ $result->po_number ?? '-' }}

--- a/resources/views/vendor/order/rfq-pdf.blade.php
+++ b/resources/views/vendor/order/rfq-pdf.blade.php
@@ -166,7 +166,7 @@
                                     </td>
                                     
                                     <td style="width: 35%;">
-                                        <p class="fc1"><b>Order Date : </b><?php echo date('d/m/Y', strtotime($order->created_at)); ?></p>
+                                        <p class="fc1"><b>Order Date : </b><?php echo date('d-m-Y', strtotime($order->created_at)); ?></p>
                                     </td>
                                 </tr>
                                 <tr>
@@ -198,7 +198,7 @@
                                         <p class="fc1"><b>RFQ NO: </b><?php echo $order->rfq_id; ?></p>
                                     </td>
                                     <td style="width: 50%;">
-                                        <p class="fc1"><b>RFQ Date : </b><?php echo date('d/m/Y' ,strtotime($order->rfq->created_at)); ?></p>
+                                        <p class="fc1"><b>RFQ Date : </b><?php echo date('d-m-Y' ,strtotime($order->rfq->created_at)); ?></p>
                                     </td>
                                 </tr>
                                 <tr></tr>

--- a/resources/views/vendor/order/rfq-view.blade.php
+++ b/resources/views/vendor/order/rfq-view.blade.php
@@ -47,7 +47,7 @@ ul.add-FQR-list li {
             <div class="card-body">
                 <ul class="add-FQR-list">
                     <li>Order No: {{ $order->po_number }}</li>
-                    <li>Order Date: {{ date('d/m/Y', strtotime($order->created_at)) }}</li>
+                    <li>Order Date: {{ date('d-m-Y', strtotime($order->created_at)) }}</li>
                     <li>Buyer Order Number: {{ $order->buyer_order_number ?? '-' }}</li>
                     <li>Buyer Name: {{ $order->buyer->legal_name ?? '-' }}</li>
                     <li>RFQ No: {{ $order->rfq_id ?? '-' }}</li>

--- a/resources/views/vendor/rfq-received/partials/table.blade.php
+++ b/resources/views/vendor/rfq-received/partials/table.blade.php
@@ -51,7 +51,7 @@
             @endphp
 
             <td class="align-middle">{{ $result->rfq_id }}</td>
-            <td class="align-middle">{{ date('d/m/Y', strtotime($result->created_at)) }}</td>
+            <td class="align-middle">{{ date('d-m-Y', strtotime($result->created_at)) }}</td>
             <td>
                 @if($product)
                     {{ $product->division->division_name ?? '-' }} >

--- a/resources/views/vendor/setting/profile.blade.php
+++ b/resources/views/vendor/setting/profile.blade.php
@@ -70,7 +70,7 @@
                                                 class="text-danger">*</span></label>
                                         <input type="text" placeholder="Date format is DD/MM/YYYY" onblur="validateDateFormat(this, true);"
                                             class="form-control required date-masking" id="date_of_incorporation" name="date_of_incorporation"
-                                            value="{{ !empty($vendor->date_of_incorporation) ? date("d/m/Y", strtotime($vendor->date_of_incorporation)) : '' }}" maxlength="10">
+                                            value="{{ !empty($vendor->date_of_incorporation) ? date("d-m-Y", strtotime($vendor->date_of_incorporation)) : '' }}" maxlength="10">
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- DRY up validation logic via `validateProductData`
- Fix alias check in vendor product update
- Store vendor id correctly and sanitize file names
- Standardize dates to `dd-mm-yyyy` in vendor views

## Testing
- `vendor/bin/phpunit` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68639f38728c8327b4701edcf1eb51fc