### PR TITLE
Fix vendor product form date validation

### DIFF
--- a/public/assets/vendor/js/common.js
+++ b/public/assets/vendor/js/common.js
@@ -225,3 +225,14 @@ document.querySelectorAll('[data-bs-dismiss="modal"]').forEach(closeBtn => {
 });
 // End of Prevent aria-hidden Warning while close Modal
 
+// Utility function to disable keyboard input on elements like date pickers
+// This mirrors the helper defined in the buyer panel scripts so that vendor
+// pages can safely call `.disableKeyboard()` without JavaScript errors.
+$.fn.disableKeyboard = function () {
+  return this.each(function () {
+    $(this).on('keypress', function (event) {
+      event.preventDefault();
+    });
+  });
+};
+

--- a/resources/views/vendor/products/create.blade.php
+++ b/resources/views/vendor/products/create.blade.php
@@ -423,6 +423,9 @@ $(document).ready(function () {
       if (!request_received_date) {
           $('.request-received-date-error').text('Request received date is required***');
           hasErrors = true;
+      } else if (!/^\d{2}\/\d{2}\/\d{4}$/.test(request_received_date)) {
+          $('.request-received-date-error').text('Date must be in DD/MM/YYYY format.');
+          hasErrors = true;
       }
 
       if (hasErrors) {

--- a/resources/views/vendor/products/edit.blade.php
+++ b/resources/views/vendor/products/edit.blade.php
@@ -417,6 +417,9 @@ $(document).ready(function () {
       if (!request_received_date) {
           $('.request-received-date-error').text('Request received date is required***');
           hasErrors = true;
+      } else if (!/^\d{2}\/\d{2}\/\d{4}$/.test(request_received_date)) {
+          $('.request-received-date-error').text('Date must be in DD/MM/YYYY format.');
+          hasErrors = true;
       }
 
       if (hasErrors) {


### PR DESCRIPTION
## Summary
- add missing `disableKeyboard` helper to vendor scripts
- validate request date format in add/edit product forms

## Testing
- `phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863a5630b608327ae9fd384c9664b36