### PR TITLE
Fix disableKeyboard plugin loading

### DIFF
--- a/public/assets/buyer/js/common.js
+++ b/public/assets/buyer/js/common.js
@@ -289,12 +289,16 @@ document.querySelectorAll('input[type="file"]').forEach(function (input) {
             });
         });
     };
-    $.fn.disableKeyboard = function () {
-        return this.each(function () {
-            $(this).on('keypress', function (event) {
-                event.preventDefault();
+    // Define disableKeyboard only once to avoid conflicts if multiple jQuery
+    // versions are loaded.
+    if (typeof $.fn.disableKeyboard !== 'function') {
+        $.fn.disableKeyboard = function () {
+            return this.each(function () {
+                $(this).on('keypress', function (event) {
+                    event.preventDefault();
+                });
             });
-        });
-    };
+        };
+    }
     
 })(jQuery);

--- a/public/assets/vendor/js/common.js
+++ b/public/assets/vendor/js/common.js
@@ -228,11 +228,15 @@ document.querySelectorAll('[data-bs-dismiss="modal"]').forEach(closeBtn => {
 // Utility function to disable keyboard input on elements like date pickers
 // This mirrors the helper defined in the buyer panel scripts so that vendor
 // pages can safely call `.disableKeyboard()` without JavaScript errors.
-$.fn.disableKeyboard = function () {
-  return this.each(function () {
-    $(this).on('keypress', function (event) {
-      event.preventDefault();
+// Define the plugin only if it doesn't already exist to avoid conflicts when
+// multiple versions of jQuery are present.
+if (typeof $.fn.disableKeyboard !== 'function') {
+  $.fn.disableKeyboard = function () {
+    return this.each(function () {
+      $(this).on('keypress', function (event) {
+        event.preventDefault();
+      });
     });
-  });
-};
+  };
+}
 


### PR DESCRIPTION
## Summary
- ensure `disableKeyboard` jQuery plugin only defined once in vendor/buyer scripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863aa0a4afc83279f7c37fa12fa94c0